### PR TITLE
Update api_utilities.go

### DIFF
--- a/api_utilities.go
+++ b/api_utilities.go
@@ -9,7 +9,7 @@ import (
 type UtilityPaymentInput struct {
 	TransactionID    string  `json:"transid"`
 	UtilityCode      string  `json:"utilitycode"`
-	UtilityReference string  `json:"utilref"`
+	UtilityReference string  `json:"utilityref"`
 	Amount           float64 `json:"amount"`
 	Vendor           string  `json:"vendor"`
 	Pin              string  `json:"pin"`


### PR DESCRIPTION
According to selcom utility api found here
https://developers.selcommobile.com/?javascript#utility-payment-request

they're utilityReference json attr is utilityref and NOT utilref thus causing this error in production, error from selcom

{
  "error": "error: response: {\"transid\":\"00853d9e-4c26-4923-9eaf-be3d285f085b\",\"reference\":\"S19930916608\",\"resultcode\":\"412\",\"result\":\"FAIL\",\"message\":\"Parameter utilityref is invalid or missing\",\"data\":[]}"
}

after checking the core lib found that bug kindly fix that