### PR TITLE
add process order feature

### DIFF
--- a/api_checkout.go
+++ b/api_checkout.go
@@ -121,7 +121,7 @@ func (cln *Client) CreateOrderMinimal(ctx context.Context, order OrderInputMinim
 // Process Order - Wallet Pull Payment
 // Process Order api allows the ecommerce website to process an order using mobile wallets directly without redirecting the user to payment gateway page.
 // Can be used for in-app payments where users can select linked mobile numbers, tigger this api call to reiceve a PUSH ussd from the mobile wallet to complete the transaction.
-
+// THIS COMPLETES USSD-PUSH REQ.(neccessary step, since order can be invoded later in time)
 func (cln *Client) ProcessOrder(ctx context.Context, order ProcessOrderRequest) (ProcessOrderResponse, error) {
 	url := fmt.Sprintf("%s/%s/checkout/wallet-payment", cln.host, version)
 


### PR DESCRIPTION
Recently i was intergrating push ussd using this sdk client, i notice we have only CreateOrder Minal only creates order details to selcom for later process as selcom refers
"Can be used for in-app payments where users can select linked mobile numbers, tigger this api call to reiceve a PUSH ussd from the mobile wallet to complete the transaction."

Meaning id used to create order from minimal can be processed later intime
Refer(https://developers.selcommobile.com/#process-order-wallet-pull-payment)

Attached Conversation with selcom team i have patched updated request approval.

<img width="897" alt="Screenshot 2025-06-21 at 12 45 50" src="https://github.com/user-attachments/assets/4c386909-721d-438c-9b00-e2cb7ca5fcb7" />


<img width="890" alt="Screenshot 2025-06-21 at 12 45 42" src="https://github.com/user-attachments/assets/d043ea17-c4bf-42e0-8420-ab3ba00d22a1" />
